### PR TITLE
Use CAR file in generation of CommP

### DIFF
--- a/pieceio/mocks/PieceIO.go
+++ b/pieceio/mocks/PieceIO.go
@@ -15,7 +15,7 @@ type PieceIO struct {
 }
 
 // GeneratePieceCommitment provides a mock function with given fields: bs, payloadCid, selector
-func (_m *PieceIO) GeneratePieceCommitment(bs pieceio.ReadStore, payloadCid cid.Cid, selector ipld.Node) ([]byte, filestore.Path, error) {
+func (_m *PieceIO) GeneratePieceCommitment(bs pieceio.ReadStore, payloadCid cid.Cid, selector ipld.Node) ([]byte, filestore.File, error) {
 	ret := _m.Called(bs, payloadCid, selector)
 
 	var r0 []byte
@@ -27,11 +27,13 @@ func (_m *PieceIO) GeneratePieceCommitment(bs pieceio.ReadStore, payloadCid cid.
 		}
 	}
 
-	var r1 filestore.Path
-	if rf, ok := ret.Get(1).(func(pieceio.ReadStore, cid.Cid, ipld.Node) filestore.Path); ok {
+	var r1 filestore.File
+	if rf, ok := ret.Get(1).(func(pieceio.ReadStore, cid.Cid, ipld.Node) filestore.File); ok {
 		r1 = rf(bs, payloadCid, selector)
 	} else {
-		r1 = ret.Get(1).(filestore.Path)
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(filestore.File)
+		}
 	}
 
 	var r2 error

--- a/pieceio/pieceio_test.go
+++ b/pieceio/pieceio_test.go
@@ -71,7 +71,7 @@ func Test_ThereAndBackAgain(t *testing.T) {
 		deferErr := tmpFile.Close()
 		require.NoError(t, deferErr)
 		deferErr = store.Delete(tmpFile.Path())
-		require.NoError(t, deferErr )
+		require.NoError(t, deferErr)
 	}()
 	for _, b := range bytes {
 		require.NotEqual(t, 0, b)
@@ -160,9 +160,11 @@ func Test_StoreRestoreMemoryBuffer(t *testing.T) {
 		deferErr := tmpFile.Close()
 		require.NoError(t, deferErr)
 		deferErr = store.Delete(tmpFile.Path())
-		require.NoError(t, deferErr )
+		require.NoError(t, deferErr)
 	}()
 	_, err = tmpFile.Seek(0, io.SeekStart)
+	require.NoError(t, err)
+
 	for _, b := range commitment {
 		require.NotEqual(t, 0, b)
 	}
@@ -243,7 +245,7 @@ func Test_Failures(t *testing.T) {
 
 		counter := 0
 		size := 0
-		mockfile.On("Write", mock.Anything).Run(func (args mock.Arguments) {
+		mockfile.On("Write", mock.Anything).Run(func(args mock.Arguments) {
 			arg := args[0]
 			buf := arg.([]byte)
 			size := len(buf)
@@ -272,7 +274,7 @@ func Test_Failures(t *testing.T) {
 
 		counter := 0
 		size := 0
-		mockfile.On("Write", mock.Anything).Run(func (args mock.Arguments) {
+		mockfile.On("Write", mock.Anything).Run(func(args mock.Arguments) {
 			arg := args[0]
 			buf := arg.([]byte)
 			size := len(buf)
@@ -301,7 +303,7 @@ func Test_Failures(t *testing.T) {
 
 		counter := 0
 		size := 0
-		mockfile.On("Write", mock.Anything).Run(func (args mock.Arguments) {
+		mockfile.On("Write", mock.Anything).Run(func(args mock.Arguments) {
 			arg := args[0]
 			buf := arg.([]byte)
 			size := len(buf)

--- a/pieceio/types.go
+++ b/pieceio/types.go
@@ -19,6 +19,6 @@ type ReadStore interface {
 
 // PieceIO converts between payloads and pieces
 type PieceIO interface {
-	GeneratePieceCommitment(bs ReadStore, payloadCid cid.Cid, selector ipld.Node) ([]byte, filestore.Path, error)
+	GeneratePieceCommitment(bs ReadStore, payloadCid cid.Cid, selector ipld.Node) ([]byte, filestore.File, error)
 	ReadPiece(r io.Reader, bs WriteStore) (cid.Cid, error)
 }

--- a/storagemarket/impl/client_utils.go
+++ b/storagemarket/impl/client_utils.go
@@ -45,11 +45,19 @@ func (c *Client) commP(ctx context.Context, root cid.Cid) ([]byte, uint64, error
 	if err != nil {
 		return nil, 0, xerrors.Errorf("generating CommP: %w", err)
 	}
-	defer func() {
-		tmpFile.Close()
-		c.fs.Delete(tmpFile.Path())
-	}()
-	return commp[:], uint64(tmpFile.Size()), nil
+	size := tmpFile.Size()
+
+	err = tmpFile.Close()
+	if err != nil {
+		return nil, 0, xerrors.Errorf("error closing temp file: %w", err)
+	}
+
+	err = c.fs.Delete(tmpFile.Path())
+	if err != nil {
+		return nil, 0, xerrors.Errorf("error deleting temp file from filestore: %w", err)
+	}
+
+	return commp[:], uint64(size), nil
 }
 
 func (c *Client) readStorageDealResp(deal ClientDeal) (*Response, error) {


### PR DESCRIPTION
## Summary
Use PieceIO and CAR file to generate CommP.

Resolves https://github.com/filecoin-project/go-storage-market/issues/13