### PR TITLE
ci(codecov): disable status, display report

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,8 @@
+coverage:
+  precision: 2
+  round: up
+  range: "50...90"
+  status:
+    project: off
+    patch: off
+


### PR DESCRIPTION
# Goals

The project shows as failing cause of codecov... it likely will be for several months till the test coverage is up. In the meantime, let's take a slightly less agreesive approach of tracking code coverage, displaying as a report in PRs, but not breaking the build on it.